### PR TITLE
fix ascending/descending year typo

### DIFF
--- a/server.R
+++ b/server.R
@@ -88,8 +88,8 @@ shinyServer(function(input, output) {
     if(nrow(papers)>0){
     # ordering 
     papers$Year = as.numeric(papers$Year) # for sorting
-    if(input$order=='ayear'){papers = arrange(papers, -Year)} #
-    if(input$order=='dyear'){papers = arrange(papers, Year)} # 
+    if(input$order=='ayear'){papers = arrange(papers, Year)} #
+    if(input$order=='dyear'){papers = arrange(papers, -Year)} # 
     if(input$order=='journal'){papers = arrange(papers, Journal, Year)} # 
     papers$Year = as.character(papers$Year) # looks better as character
     ## select columns and return


### PR DESCRIPTION
Hi, thanks for the useful app! :)

I'm not sure if it's a typo or if I'm misunderstanding your intention, but "Ascending year" option puts 2017 at the top and 2011 at the bottom; "Descending year" does the opposite. So I switched the code for the two options.